### PR TITLE
Remove whitespace from stdout for parsing

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -116,7 +116,8 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
         : { }
 
     try {
-      const { stdout } = await exec(command, execOptions)
+      const { stdout: rawStdout } = await exec(command, execOptions)
+      const stdout = rawStdout.replace(/\s/g, '')
       const [, port] = stdout.match(portRegex)!
       const [, password] = stdout.match(passwordRegex)!
       const [, pid] = stdout.match(pidRegex)!


### PR DESCRIPTION
close #59

Depending on the window environment or windows version, there may be whitespaces in the command.

`--remoting-auth-token` could not be parsed because of those whitespaces.

It looks like a rough solution but the code will be working until change `portRegex`, `passwordRegex`, `pidRegex`.

code is tested in windows 10 and windows 11

