### PR TITLE
feat: implement options for forcing use of WMIC and Cmd on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ LeagueClientUx process. If you wish to await until a client is found, you can us
 | pollInterval | `2500` | Duration in milliseconds between each poll. No-op if awaitConnection is false. |
 | certificate | `undefined` | A plain-text self-signed certificate to authenticate to the LCU API with. This option should only be used if you're self-signing with a certificate which is not the one Riot Games provides on their developer page. League Connect will default to using Riot's own self-signed certificate for authentication. If you're of what this option does, you should probably not use it. |
 | unsafe | `false` | If you do not wish to authenticate safely using a self-signed certificate you can authorize while ignoring any certificate rejections. To authenticate this way, set unsafe to `true`. The custom certificate option will take precedence over this, meaning this option is meaningless if a custom certificate is provided. |
+| useDeprecatedWmic | `false` | Use deprecated Windows WMIC command line over Get-CimInstance. Does nothing if the system is not running on Windows. |
+| windowsShell | `powershell` | Set the Windows shell to use. Either powershell or cmd. |
 
 ```js
 import { authenticate } from 'league-connect'

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import cp from 'child_process'
 import path from 'path'
 import util from 'util'
+import os from 'os'
 
 const exec = util.promisify(cp.exec)
 
@@ -9,59 +10,59 @@ const DEFAULT_NAME = 'LeagueClientUx'
 const DEFAULT_POLL_INTERVAL = 2500
 
 export interface Credentials {
-  /**
-   * The system port the LCU API is running on
-   */
-  port: number
-  /**
-   * The password for the LCU API
-   */
-  password: string
-  /**
-   * The system process id for the LeagueClientUx process
-   */
-  pid: number
-  /**
-   * Riot Games' self-signed root certificate (contents of .pem). If
-   * it is `undefined` then unsafe authentication will be used.
-   */
-  certificate?: string
+    /**
+     * The system port the LCU API is running on
+     */
+    port: number
+    /**
+     * The password for the LCU API
+     */
+    password: string
+    /**
+     * The system process id for the LeagueClientUx process
+     */
+    pid: number
+    /**
+     * Riot Games' self-signed root certificate (contents of .pem). If
+     * it is `undefined` then unsafe authentication will be used.
+     */
+    certificate?: string
 }
 
 export interface AuthenticationOptions {
-  /**
-   * League Client process name. Set to RiotClientUx if you would like to
-   * authenticate with the Riot Client
-   *
-   * Defaults: LeagueClientUx
-   */
-  name?: string
-  /**
-   * Does not return before the League Client has been detected. This means the
-   * function stays unresolved until a League has been found.
-   *
-   * Defaults: false
-   */
-  awaitConnection?: boolean
-  /**
-   * The time duration in milliseconds between each attempt to locate a League
-   * Client process. Has no effect if awaitConnection is false
-   *
-   * Default: 2500
-   */
-  pollInterval?: number
-  /**
-   * Riot Games' self-signed root certificate (contents of .pem)
-   *
-   * Default: version of certificate bundled in package
-   */
-  certificate?: string
-  /**
-   * Do not authenticate requests with Riot Games' self-signed root certificate
-   *
-   * Default: true if `certificate` is `undefined`
-   */
-  unsafe?: boolean
+    /**
+     * League Client process name. Set to RiotClientUx if you would like to
+     * authenticate with the Riot Client
+     *
+     * Defaults: LeagueClientUx
+     */
+    name?: string
+    /**
+     * Does not return before the League Client has been detected. This means the
+     * function stays unresolved until a League has been found.
+     *
+     * Defaults: false
+     */
+    awaitConnection?: boolean
+    /**
+     * The time duration in milliseconds between each attempt to locate a League
+     * Client process. Has no effect if awaitConnection is false
+     *
+     * Default: 2500
+     */
+    pollInterval?: number
+    /**
+     * Riot Games' self-signed root certificate (contents of .pem)
+     *
+     * Default: version of certificate bundled in package
+     */
+    certificate?: string
+    /**
+     * Do not authenticate requests with Riot Games' self-signed root certificate
+     *
+     * Default: true if `certificate` is `undefined`
+     */
+    unsafe?: boolean
 }
 
 /**
@@ -69,18 +70,18 @@ export interface AuthenticationOptions {
  * League Client supports. The Client runs on windows, linux or darwin.
  */
 export class InvalidPlatformError extends Error {
-  constructor() {
-    super('process runs on platform client does not support')
-  }
+    constructor() {
+        super('process runs on platform client does not support')
+    }
 }
 
 /**
  * Indicates that the league client could not be found
  */
 export class ClientNotFoundError extends Error {
-  constructor() {
-    super('league client process could not be located')
-  }
+    constructor() {
+        super('league client process could not be located')
+    }
 }
 
 /**
@@ -104,16 +105,14 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
     const passwordRegex = /--remoting-auth-token=([\w-_]+)/
     const pidRegex = /--app-pid=([0-9]+)/
     const isWindows = process.platform === 'win32';
+    const iswin7 = isWindows && os.release().indexOf('6.1') != -1;
 
     const command =
       isWindows
-        ? `Get-CimInstance -Query "SELECT * from Win32_Process WHERE name LIKE '${name}.exe'" | Select-Object CommandLine | fl`
+        ? iswin7 ? `wmic process where caption='${name}.exe' get commandline`
+          : `Get-CimInstance -Query "SELECT * from Win32_Process WHERE name LIKE '${name}.exe'" | Select-Object CommandLine | fl`
         : `ps x -o args | grep '${name}'`
-
-    const execOptions =
-      isWindows
-        ? { shell: 'powershell' }
-        : { }
+        const execOptions = isWindows ? iswin7 ? {shell: 'cmd'} : {shell: 'powershell'} : {}
 
     try {
       // See #59 and #60 for why we are replacing all whitespace in the raw output

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -10,59 +10,59 @@ const DEFAULT_NAME = 'LeagueClientUx'
 const DEFAULT_POLL_INTERVAL = 2500
 
 export interface Credentials {
-    /**
-     * The system port the LCU API is running on
-     */
-    port: number
-    /**
-     * The password for the LCU API
-     */
-    password: string
-    /**
-     * The system process id for the LeagueClientUx process
-     */
-    pid: number
-    /**
-     * Riot Games' self-signed root certificate (contents of .pem). If
-     * it is `undefined` then unsafe authentication will be used.
-     */
-    certificate?: string
+  /**
+   * The system port the LCU API is running on
+   */
+  port: number
+  /**
+   * The password for the LCU API
+   */
+  password: string
+  /**
+   * The system process id for the LeagueClientUx process
+   */
+  pid: number
+  /**
+   * Riot Games' self-signed root certificate (contents of .pem). If
+   * it is `undefined` then unsafe authentication will be used.
+   */
+  certificate?: string
 }
 
 export interface AuthenticationOptions {
-    /**
-     * League Client process name. Set to RiotClientUx if you would like to
-     * authenticate with the Riot Client
-     *
-     * Defaults: LeagueClientUx
-     */
-    name?: string
-    /**
-     * Does not return before the League Client has been detected. This means the
-     * function stays unresolved until a League has been found.
-     *
-     * Defaults: false
-     */
-    awaitConnection?: boolean
-    /**
-     * The time duration in milliseconds between each attempt to locate a League
-     * Client process. Has no effect if awaitConnection is false
-     *
-     * Default: 2500
-     */
-    pollInterval?: number
-    /**
-     * Riot Games' self-signed root certificate (contents of .pem)
-     *
-     * Default: version of certificate bundled in package
-     */
-    certificate?: string
-    /**
-     * Do not authenticate requests with Riot Games' self-signed root certificate
-     *
-     * Default: true if `certificate` is `undefined`
-     */
-    unsafe?: boolean
+  /**
+   * League Client process name. Set to RiotClientUx if you would like to
+   * authenticate with the Riot Client
+   *
+   * Defaults: LeagueClientUx
+   */
+  name?: string
+  /**
+   * Does not return before the League Client has been detected. This means the
+   * function stays unresolved until a League has been found.
+   *
+   * Defaults: false
+   */
+  awaitConnection?: boolean
+  /**
+   * The time duration in milliseconds between each attempt to locate a League
+   * Client process. Has no effect if awaitConnection is false
+   *
+   * Default: 2500
+   */
+  pollInterval?: number
+  /**
+   * Riot Games' self-signed root certificate (contents of .pem)
+   *
+   * Default: version of certificate bundled in package
+   */
+  certificate?: string
+  /**
+   * Do not authenticate requests with Riot Games' self-signed root certificate
+   *
+   * Default: true if `certificate` is `undefined`
+   */
+  unsafe?: boolean
 }
 
 /**
@@ -70,18 +70,18 @@ export interface AuthenticationOptions {
  * League Client supports. The Client runs on windows, linux or darwin.
  */
 export class InvalidPlatformError extends Error {
-    constructor() {
-        super('process runs on platform client does not support')
-    }
+  constructor() {
+    super('process runs on platform client does not support')
+  }
 }
 
 /**
  * Indicates that the league client could not be found
  */
 export class ClientNotFoundError extends Error {
-    constructor() {
-        super('league client process could not be located')
-    }
+  constructor() {
+    super('league client process could not be located')
+  }
 }
 
 /**
@@ -112,11 +112,11 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
         ? iswin7 ? `wmic process where caption='${name}.exe' get commandline`
           : `Get-CimInstance -Query "SELECT * from Win32_Process WHERE name LIKE '${name}.exe'" | Select-Object CommandLine | fl`
         : `ps x -o args | grep '${name}'`
-        const execOptions = isWindows ? iswin7 ? {shell: 'cmd'} : {shell: 'powershell'} : {}
+    const execOptions = isWindows ? iswin7 ? {shell: 'cmd'} : {shell: 'powershell'} : {}
 
     try {
       // See #59 and #60 for why we are replacing all whitespace in the raw output
-      const { stdout: rawStdout } = await exec(command, execOptions)
+      const {stdout: rawStdout} = await exec(command, execOptions)
       const stdout = rawStdout.replace(/\s/g, '')
       const [, port] = stdout.match(portRegex)!
       const [, password] = stdout.match(passwordRegex)!
@@ -130,8 +130,8 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
         ? options!.certificate
         : // Otherwise: does the user want unsafe requests?
         unsafe
-        ? undefined
-        : // Didn't specify, use our own certificate
+          ? undefined
+          : // Didn't specify, use our own certificate
           RIOT_GAMES_CERT
 
       return {


### PR DESCRIPTION
Add win7 judgment on the original basis.
```js
if (os.release().indexOf('6.1') != -1){
  // it means win7
}
```
and we use wmic.
#67 