### PR TITLE
fix: updated the way to add using Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ League Connect ships as an NPM module, installable through Yarn or NPM. To add t
 package to your project, install it through your package manager of choice.
 
 ```sh
-$ yarn install league-connect
+$ yarn add league-connect
 # Or ...
 $ npm install league-connect
 ```


### PR DESCRIPTION
Yarn does not support adding packages via `yarn install`, so packages must be installed with `yarn add`. I have updated the README to show this.
Yarn's documentation showing this: https://classic.yarnpkg.com/en/docs/cli/install