### PR TITLE
fix: password regex

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -115,7 +115,7 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
   async function tryAuthenticate() {
     const name = options?.name ?? DEFAULT_NAME
     const portRegex = /--app-port=([0-9]+)/
-    const passwordRegex = /--remoting-auth-token=([\w-_]+)/
+    const passwordRegex = /--remoting-auth-token=([\w-]+)/
     const pidRegex = /--app-pid=([0-9]+)/
     const isWindows = process.platform === 'win32'
 


### PR DESCRIPTION
fix the password regex pattern, `\w-_` creates an invalid range sequence and `\w` meta already contains an underscore `_`