### PR TITLE
fix: Authentication errors

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -109,6 +109,13 @@ export interface ConnectionOptions {
   __internalMockCallback?: () => void
 }
 
+/**
+ * Creates a WebSocket connection to the League Client
+ * @param {ConnectionOptions} [options] Options that will be used to authenticate to the League Client
+ *
+ * @throws Error If the connection fails due to ECONNREFUSED
+ * @throws WebSocket.ErrorEvent If the connection fails for any other reason
+ */
 export async function createWebSocketConnection(options: ConnectionOptions = {}): Promise<LeagueWebSocket> {
   const credentials = await authenticate(options.authenticationOptions)
   const url = `wss://riot:${credentials.password}@127.0.0.1:${credentials.port}`


### PR DESCRIPTION
This PR fixes the issue reported in #107 that the recent regex change introduced.
Summary of changes made:
### Authentication.ts
- Changed the command used in PowerShell. ``-ExpandProperty`` gets rid of the need for ``Format-List``. 
- Changed ``stdout`` from removing spaces to removing newlines. This should fix the original formatting issues that were brought up in #59 
- Changed the port, password, and pid regex. This should match all types of auth-tokens https://regexr.com/7alur
- Added ``__internalDebug`` to AuthenticationOptions to help easier debug issues with authentication. When set to true, it will print the full error into console.
- Added a check to see if the League client is being run as admin and the current program is not. This only works with PowerShell, and I have not found a way to do it using cmd. This will use the newly made ``ClientElevatedPermsError`` error. If the user has ``awaitConnection`` set to true, it will still error out, but I can change this if requested. 
- Updated the JSDocs to mark ``options`` as optional and document the potential errors
### Webhook.ts
- Added JSDocs to ``createWebSocketDocumentation``
