### PR TITLE
Regex Unit Testing, Refactoring, and Documentation Cleanup

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -114,6 +114,24 @@ export class ClientElevatedPermsError extends Error {
 }
 
 /**
+ * Indicates that the League Client process arguments could not be parsed
+ */
+export class ProcessArgsParsingError extends Error {
+  public readonly rawStdout: string | undefined
+  public readonly port: string | undefined
+  public readonly password: string | undefined
+  public readonly pid: string | undefined
+
+  constructor(rawStdout?: string, port?: string, password?: string, pid?: string) {
+    super('Failed to parse process arguments')
+    this.rawStdout = rawStdout
+    this.port = port
+    this.password = password
+    this.pid = pid
+  }
+}
+
+/**
  * Locates a League Client and retrieves the credentials for the LCU API
  * from the found process
  *

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -174,7 +174,7 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
 /**
  * Retrieves the command line arguments for the League Client or options.name if provided.
  *
- * @param {AuthenticationOptions} options Authentication options provided by the user, if any
+ * @param {AuthenticationOptions} [options] Authentication options provided by the user, if any
  * @throws {ClientNotFoundError} If the League Client process is not found.
  * @throws {ClientElevatedPermsError} If the user is running the client as an administrator, preventing process detection.
  * @internal

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -223,9 +223,9 @@ export async function getProcessArgs(options?: AuthenticationOptions): Promise<s
  * @internal
  */
 export function parseProcessArgs(rawStdout: string, unsafe: boolean = false, cert?: string): Credentials {
-  const portRegex = /--app-port=([0-9]+)(?= *"| --)/
-  const passwordRegex = /--remoting-auth-token=(.+?)(?= *"| --)/
-  const pidRegex = /--app-pid=([0-9]+)(?= *"| --)/
+  const portRegex = /--app-port=([0-9]+)(?= *"| --|$)/
+  const passwordRegex = /--remoting-auth-token=(.+?)(?= *"| --|$)/
+  const pidRegex = /--app-pid=([0-9]+)(?= *"| --|$)/
 
   // Remove newlines from stdout
   const stdout = rawStdout.replace(/\n|\r/g, '')

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -158,19 +158,17 @@ export async function authenticate(options?: AuthenticationOptions): Promise<Cre
   if (options?.awaitConnection) {
     // Poll until a client is found, attempting to resolve every
     // `options.pollInterval` milliseconds
+    const pollInterval = options?.pollInterval ?? DEFAULT_POLL_INTERVAL
     return new Promise(function self(resolve, reject) {
       tryAuthenticate()
-        .then((result) => {
-          resolve(result)
-        })
+        .then(resolve)
         .catch((err) => {
           if (err instanceof ClientElevatedPermsError) reject(err)
-          setTimeout(self, options?.pollInterval ?? DEFAULT_POLL_INTERVAL, resolve, reject)
+          setTimeout(self, pollInterval, resolve, reject)
         })
     })
-  } else {
-    return tryAuthenticate()
   }
+  return tryAuthenticate()
 }
 
 /**

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,8 +1,8 @@
-import cp from 'child_process'
-import util from 'util'
+import { exec as nodeExec } from 'child_process'
+import { promisify } from 'util'
 import { RIOT_GAMES_CERT } from './cert.js'
 
-const exec = util.promisify<typeof cp.exec.__promisify__>(cp.exec)
+const exec = promisify(nodeExec)
 
 const DEFAULT_NAME = 'LeagueClientUx'
 const DEFAULT_POLL_INTERVAL = 2500

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ export {
   type AuthenticationOptions,
   type Credentials,
   ClientNotFoundError,
-  InvalidPlatformError
+  InvalidPlatformError,
+  ClientElevatedPermsError,
+  ProcessArgsParsingError
 } from './authentication.js'
 export { LeagueClient, type LeagueClientOptions } from './client.js'
 export { createHttp1Request, Http1Response } from './http.js'
@@ -13,7 +15,8 @@ export {
   ConnectionOptions,
   LeagueWebSocket,
   EventResponse,
-  EventCallback
+  EventCallback,
+  LeagueWebSocketInitError
 } from './websocket.js'
 export { DEPRECATED_request, DEPRECATED_RequestOptions, DEPRECATED_Response } from './request_deprecated.js'
 export { DEPRECATED_connect } from './websocket_deprecated.js'

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -7,9 +7,12 @@ describe('league client adapter', () => {
     const client = new LeagueClient(credentials)
 
     client.start()
-    setTimeout(() => {
-      client.stop()
-    }, 5000)
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        client.stop()
+        resolve()
+      }, 5000)
+    })
   }, 10_000)
 
   // Manual test

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -68,6 +68,18 @@ export class LeagueWebSocket extends WebSocket {
   }
 }
 
+/**
+ * Error thrown when the WebSocket initialization fails
+ */
+export class LeagueWebSocketInitError extends Error {
+  public readonly errorEvent: WebSocket.ErrorEvent
+
+  constructor(message: string, originalError: WebSocket.ErrorEvent) {
+    super(message)
+    this.errorEvent = originalError
+  }
+}
+
 export interface ConnectionOptions {
   /**
    * Options that will be used to authenticate to the LCU WebSocket API

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -148,14 +148,9 @@ export async function createWebSocketConnection(options: ConnectionOptions = {})
       headers: {
         Authorization: 'Basic ' + Buffer.from(`riot:${credentials.password}`).toString('base64')
       },
+      // Use the certificate if it is provided, otherwise disable certificate verification
       agent: new https.Agent(
-        typeof credentials?.certificate === 'undefined'
-          ? {
-              rejectUnauthorized: false
-            }
-          : {
-              ca: credentials?.certificate
-            }
+        credentials?.certificate ? { ca: credentials?.certificate } : { rejectUnauthorized: false }
       )
     })
 


### PR DESCRIPTION
## Description

This PR intends to add unit testing, clean up some documentation, make debugging easier for users, and improve code readability in certain areas. It was important when making these changes to make sure that none of these changes would break the existing code that users have written while using this library, and I believe I've succeeded with that. There are a lot of changes, so I'd love to hear your feedback. I tried to make sure that I documented all the changes in this PR, and I attempted to break it up into multiple small commits to make changes easier to review. However, if I have missed anything or if you have any questions, please let me know.

## Changes

### Authentication.ts

-   Updated imports to only import the `exec` and `promisfy` functions instead of the entire modules. This should make the code a bit more efficient and easier to read.
-   Updated the declaration of `exec` to match the new imports.
-   Added a new `ProcessArgsParsingError` class for when there's an issue with the regex matching. Included public `rawStdout`, `port`, `password`, and `pid` properties to the class for easier debugging.
-   Clarified that `tryAuthenticate()` returns a promise that resolves to the `Credentials` object.
-   Removed an unnecessary else statement in `authenticate()`.
-   Separated getting the command line arguments and matching them into two separate functions: `getProcessArgs()` and `parseProcessArgs()`. Both functions are exported; however, they are marked with `@internal` and are not exported in `index.ts`, so TypeScript won't export their definitions.
-   `parseProcessArgs()`
    -   Set three arguments for the function: `rawStdout`, which should contain the command line arguments; `unsafe`, a boolean that determines if the user wants to connect in unsafe mode (with an undefined certificate), which defaults to false; and `certificate`, an optional string that contains a user provided certificate.
    -   Added `|$` to the end of each regex to ensure that if the port, password, or pid is the last argument, it still matches properly.
    -   Changed from array destructuring as it would throw an error if there was no match. Now, the variable will be set to undefined if there's no match.
    -   Added a check to ensure that the port, password, and pid are all defined and the correct type before returning the object. If not, it will throw the new `ProcessArgsParsingError` error.
    -   Attempted to simplify the code for the certificate flow and added more comments to explain what's going on.

### Authentication.test.ts

-   Made an expected credentials object that is used in most new tests and is reset before each test.
-   Added tests to ensure that the `getProcessArgs()` function and regex inside of it works as expected. Those tests use different stdout formats that have been seen in issues. The new tests are:
    -   Command line arguments separated by spaces.
    -   Command line arguments surrounded by quotes.
    -   Including symbols in the auth token.
    -   Using no certificate/unsafe mode.
    -   Using a custom certificate which in this case is the default certificate without the first line.
    -   Invalid command line arguments. The error class should return what was matched and the stdout that was passed in.

Note: `PLAINTEXT_CERT` doesn't perfectly match the default certificate as it's missing a new line at the beginning. I'm unsure if this was intentional, but I used that difference to do testing with a different certificate.

### Webhook.ts

-   Added an internal `ErrorCode` enum. This is used by the error handler to relay what type of error occurred and what action to take.
-   Removed `options.__internalMockFaultyConnection` as it is no longer needed for testing.
-   Added a new `LeagueWebSocketInitError` class for when there's an issue initializing the websocket. The original error event is passed using the `errorEvent` property. Although this is a long class name, I felt it was important to clarify that this error happens during initialization and not after it's connected.
-   Changed the https.Agent ternary operator syntax in an attempt to make it more readable.
-   Extracted the error handler into its own function, `errorHandler()`, to assist in easier testing. This function is exported; however, it is also marked with `@internal`, so TypeScript won't export it's definition.
-   `errorHandler()` has two arguments for the function. `err` accepts the error thrown by the webhook and `options` which is the options the user provided when creating the webhook. Returns a ErrorCode enum value.
-   `ws.onerror` was updated to call the new `errorHandler()` function and pass the error and options. The return value is then used to determine what action to take.

### Webhook.test.ts

-   Created a `MockWebSocket` class that extends the `EventEmitter` class. This class is used to mock the websocket connection errors.
-   Added beforeEach function to reset the mock callback and websocket before each test.
-   Added a new set of tests that do not _require_ the client to be running, but if the client is running, it will not interfere with the tests. Added tests are:
    -   Handling an ECONNREFUSED error with `maxRetries` set to 0.
    -   Handling an ECONNREFUSED error with `maxRetries` set to 3 and `pollInterval` set to 500. This test is truly run 4 times as the first attempt is not considered a retry.
    -   Handling a different error. `Unknown` is used for this test, but it could be any error.
-   Changed the test for creating a websocket after multiple retries since `__internalMockFaultyConnection` was removed.
-   Added a test to ensure the error handler works with the real websocket. This is used to verify the `ws.onerror` part of the code works as expected.

### Client.test.ts

-   Fixed a timeout that was causing the tests not to close properly.

### index.ts

-   Added missing export `ClientElevatedPermsError` class.
-   Added new classes `ProcessArgsParsingError` and `LeagueWebSocketInitError` to the export.
